### PR TITLE
Avoid possible null exception in ConvertIntermediateToObject when accesing VariationContext

### DIFF
--- a/src/Our.Umbraco.MultilanguageTextbox.Core/MultiLanguageTextboxValueConverter.cs
+++ b/src/Our.Umbraco.MultilanguageTextbox.Core/MultiLanguageTextboxValueConverter.cs
@@ -63,7 +63,7 @@ namespace Our.Umbraco.MultilanguageTextbox.Core
 
             if (cultureTexts.Any())
             {
-                var currentCulture = this.variationContextAccessor.VariationContext.Culture;
+                var currentCulture = this.variationContextAccessor.VariationContext?.Culture ?? string.Empty;
 
                 var currentCultureText = cultureTexts.FirstOrDefault(x => x.Culture.InvariantEquals(currentCulture));
 


### PR DESCRIPTION
Currently it is possible that variationContextAccessor.VariationContext is null is some contexts, so to avoid throwing a null exception, I'm letting it default to empty string.